### PR TITLE
CIF-1335 - Add introspection support in the Magento GraphQL library

### DIFF
--- a/codegen/lib/graphql_java_gen.rb
+++ b/codegen/lib/graphql_java_gen.rb
@@ -78,7 +78,7 @@ class GraphQLJavaGen
   end
 
   def write_entities(path)
-    schema.types.reject{ |type| type.name.start_with?('__') || type.scalar? }.each do |type|
+    schema.types.reject{ |type| type.scalar? }.each do |type|
       case type.kind when 'OBJECT', 'INTERFACE', 'UNION'
                        File.write(path + "/#{type.name}QueryDefinition.java", generate_entity("QueryDefinition.java", type))
                        File.write(path + "/#{type.name}Query.java", generate_entity("Query.java", type))

--- a/codegen/lib/graphql_java_gen/templates/Object.java.erb
+++ b/codegen/lib/graphql_java_gen/templates/Object.java.erb
@@ -48,7 +48,30 @@ import java.util.Map;
                         responseData.put(key, jsonAsString(field.getValue(), key));
                         break;
                       }
+                      <%if class_name == "Query" %>
                       
+                      case "__schema": {
+                        __Schema optional1 = null;
+                        if (!field.getValue().isJsonNull()) {
+                            optional1 = new __Schema(jsonAsObject(field.getValue(), key));
+                        }
+    
+                        responseData.put(key, optional1);
+    
+                        break;
+                      }
+    
+                      case "__type": {
+                        __Type optional1 = null;
+                        if (!field.getValue().isJsonNull()) {
+                            optional1 = new __Type(jsonAsObject(field.getValue(), key));
+                        }
+    
+                        responseData.put(key, optional1);
+    
+                        break;
+                      }
+                      <% end %>
                       default: {
                         readCustomField(fieldName, field.getValue());
                       }
@@ -99,6 +122,22 @@ import java.util.Map;
                     public <%= class_name %> set<%= field.classify_name %>(<%= java_output_type(field.type) %> arg) {
                       optimisticData.put(getKey("<%= field.name %>"), arg);
                       return this;
+                    }
+                <% end %>
+                <% if class_name == "Query" %>
+
+                    /**
+                    * The root __schema field for introspection queries.
+                    */
+                    public __Schema __getSchema() {
+                      return (__Schema) get("__schema");
+                    }
+              
+                    /**
+                    * The root __type field for introspection queries.
+                    */
+                    public __Type __getType() {
+                      return (__Type) get("__type");
                     }
                 <% end %>
 

--- a/codegen/lib/graphql_java_gen/templates/Query.java.erb
+++ b/codegen/lib/graphql_java_gen/templates/Query.java.erb
@@ -110,4 +110,36 @@ public class <%= type.name %>Query extends AbstractQuery<<%= type.name %>Query> 
           return _queryBuilder.toString();
       }
     <% end %>
+    <% if type.name == "Query" %>
+
+      /**
+      * The root __schema field for introspection queries.
+      */
+      public QueryQuery __schema(__SchemaQueryDefinition queryDef) {
+          startField("__schema");
+
+          _queryBuilder.append('{');
+          queryDef.define(new __SchemaQuery(_queryBuilder));
+          _queryBuilder.append('}');
+
+          return this;
+      }
+
+      /**
+      * The root __type field for introspection queries.
+      */
+      public QueryQuery __type(String name, __TypeQueryDefinition queryDef) {
+        startField("__type");
+
+        _queryBuilder.append("(name:");
+        AbstractQuery.appendQuotedString(_queryBuilder, name);
+        _queryBuilder.append(')');
+
+        _queryBuilder.append('{');
+        queryDef.define(new __TypeQuery(_queryBuilder));
+        _queryBuilder.append('}');
+
+        return this;
+      }
+    <% end %>
 }


### PR DESCRIPTION
- enable generation of introspection classes (with name starting with __)
- added support to parse and get the __schema and __type fields in the root Query type

## How Has This Been Tested?

Tests for the generated classes have been added in https://github.com/adobe/commerce-cif-magento-graphql/pull/14

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
